### PR TITLE
ci: enable minimal CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,59 @@
+name: Build
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronized
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        include:
+          - name: obc-native
+            board: native_sim
+            path: ./apps/obc
+          - name: obc-nucleo
+            board: nucleo_g431rb
+            path: ./apps/obc
+          - name: pay-native
+            board: native_sim
+            path: ./apps/pay
+          - name: pay-nucleo
+            board: nucleo_h743zi
+            path: ./apps/pay
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          chmod +x ./scripts/install_dependencies.sh
+          ./scripts/install_dependencies.sh
+
+      - name: Setup Python venv
+        run: |
+          chmod +x ./scripts/setup_python_venv.sh
+          ./scripts/setup_python_venv.sh
+
+      - name: Setup west workspace
+        run: |
+          chmod +x ./scripts/setup_west_workspace.sh
+          ./scripts/setup_west_workspace.sh
+
+      - name: Build app
+        run: |
+          source ../.venv/bin/activate
+          source ../zephyr/zephyr-env.sh
+          west -v build -b ${{ matrix.board }} ${{ matrix.path }} -p

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -1,0 +1,33 @@
+name: Checkpatch
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronized
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  patch_check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: checkout_repository
+        uses: actions/checkout@v4
+
+      - name: Install Perl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y perl
+
+      - name: Run checkpatch
+        working-directory: ${{ github.workspace }}
+        run: |
+          chmod +x ./scripts/run_checkpatch.sh
+          ./scripts/run_checkpatch.sh

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -1,0 +1,52 @@
+name: Compliance check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronized
+
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  compliance-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install Perl
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y perl
+
+      - name: Run compliance check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x ./scripts/compliance.pl
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            echo "Running on PR — checking all commits..."
+            commits=$(gh pr view ${{ github.event.number }} --repo ${{ github.repository }} --json commits --jq '.commits[].oid')
+          else
+            echo "Running on push to main — checking HEAD only..."
+            commits=$(git rev-parse HEAD)
+          fi
+
+          echo "Commits to check:"
+          echo "$commits"
+
+          for commit in $commits; do
+            echo "Running compliance check on commit: $commit"
+            ./scripts/compliance.pl "$commit"
+          done


### PR DESCRIPTION
This patch enables minimal CI for finch-flight-software.

Build obc and pay apps against nucleo boards, and native_sim (remove native_sim and replace it with obc and pay boards when they become available; perhaps keep nucleo boards with overlays).

Run checkpatch.pl.

Run a compliance check on every commit in a PR.