### PR TITLE
compliance: return non-zero when check fails

### DIFF
--- a/scripts/compliance.pl
+++ b/scripts/compliance.pl
@@ -2,6 +2,8 @@
 use strict;
 use warnings;
 
+my $exit_code = 0;
+
 if (@ARGV < 1) {
     die "Usage: $0 <commit_hash> [<commit_hash> ...]\n";
 }
@@ -74,8 +76,11 @@ foreach my $commit (@ARGV) {
 
     if ($error) {
 	print "Commit $commit has issues. Please review the above messages.\n";
+	$exit_code = 1;
     } else {
         print "Commit $commit passed all checks.\n";
     }
     print "\n";
 }
+
+exit($exit_code);


### PR DESCRIPTION
The current implementation of compliance.pl always returns zero, regardless of the result.
Ensure the script exits with a non‑zero value on failure so that GitHub Actions CI correctly detects a failed check.