### PR TITLE
CODEOWNERS: add * to specify all files

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-@mshinjo @alexapostolu @Kevin-Caldwell
+*	@mshinjo @alexapostolu @Kevin-Caldwell


### PR DESCRIPTION
With `*`, CODEOWNERS are automatically added as PR reviewers.