### PR TITLE
README: add "Getting Started" guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,53 @@
+# Getting Started
+
+This guide covers setup on **Ubuntu 24.04 LTS** with **x86_64** processor.
+
+## System Update
+
 ```sh
-west init --local --mf west.yml && west update
+sudo apt update
+sudo apt upgrade
+```
+
+## Make an Empty Directory
+
+```sh
+mkdir ~/finch
+cd ~/finch
+```
+
+**Note:** This is because the west manifest will populate one directory above this repository.
+
+## Clone This Repository
+
+Using **HTTPS**:
+
+```sh
+git clone https://github.com/utat-ss/finch-flight-software.git
+cd finch-flight-software
+```
+
+Using **SSH**:
+
+```sh
+git clone git@github.com:utat-ss/finch-flight-software.git
+cd finch-flight-software
+```
+
+## Install Dependencies
+
+```sh
+./scripts/install_dependencies.sh
+```
+
+## Set Up Python Virtual Environment
+
+```sh
+./scripts/setup_python_venv.sh
+```
+
+## Set Up West Workspace
+
+```sh
+./scripts/setup_west_workspace.sh
+```


### PR DESCRIPTION
This commit adds a "Getting Started" guide.
The guide currently only supports Ubuntu 24.04 LTS with x86_64
processors because it utilizes scripts under `./scripts`.
Some packages are not available on other processor architectures.
