### PR TITLE
ci: correct invalid activity type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
       - reopened
-      - synchronized
+      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/checkpatch.yml
+++ b/.github/workflows/checkpatch.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
       - reopened
-      - synchronized
+      - synchronize
   push:
     branches:
       - main

--- a/.github/workflows/compliance.yml
+++ b/.github/workflows/compliance.yml
@@ -5,7 +5,7 @@ on:
     types:
       - opened
       - reopened
-      - synchronized
+      - synchronize
 
   push:
     branches:


### PR DESCRIPTION
"synchronized" is not a valid activity type.
Change "synchronized" to "synchronize" to ensure
workflows are triggered.