### PR TITLE
boards: obc: add initial support for FINCH CubeSat OBC

### DIFF
--- a/boards/obc/Kconfig.obc
+++ b/boards/obc/Kconfig.obc
@@ -1,0 +1,2 @@
+config BOARD_OBC
+        select SOC_STM32G431XX

--- a/boards/obc/board.cmake
+++ b/boards/obc/board.cmake
@@ -1,0 +1,2 @@
+board_runner_args(jlink "--device=STM32G431RB" "--speed=4000")
+include(${ZEPHYR_BASE}/boards/common/jlink.board.cmake)

--- a/boards/obc/board.yml
+++ b/boards/obc/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: obc
+  full_name: FINCH OBC
+  vendor: The FINCH CubeSat Project Contributors
+  socs:
+    - name: stm32g431xx

--- a/boards/obc/obc.dts
+++ b/boards/obc/obc.dts
@@ -1,0 +1,70 @@
+/dts-v1/;
+
+#include <st/g4/stm32g431Xb.dtsi>
+#include <st/g4/stm32g431r(6-8-b)tx-pinctrl.dtsi>
+
+/ {
+	model = "finch,obc";
+	compatible = "finch,obc";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+		act_led: led_0 {
+			gpios = <&gpioc 3 GPIO_ACTIVE_HIGH>;
+			label = "LED0";
+		};
+		wrn_led: led_1 {
+			gpios = <&gpioc 2 GPIO_ACTIVE_HIGH>;
+			label = "LED1";
+		};
+	};
+
+	aliases {
+		led0 = &act_led;
+		actled = &act_led;
+		led1 = &wrn_led;
+		wrnled = &wrn_led;
+	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(24)>;
+	status = "okay";
+};
+
+&pll {
+	div-m = <12>;
+	mul-n = <85>;
+	div-p = <7>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(170)>;
+	ahb-prescaler = <1>;
+	apb1-prescaler = <1>;
+	apb2-prescaler = <1>;
+	status = "okay";
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		slot0_partition: partition@0 {
+			label = "image-0";
+			reg = <0x00000000 DT_SIZE_K(64)>;
+		};
+	};
+};

--- a/boards/obc/obc.yml
+++ b/boards/obc/obc.yml
@@ -1,0 +1,11 @@
+identifier: finch_obc
+name: FINCH OBC
+type: mcu
+arch: arm
+toolchain:
+  - zephyr
+  - gnuarmmemb
+ram: 32
+flash: 128
+supported:
+vendor: The FINCH CubeSat Project Contributors


### PR DESCRIPTION
This patch adds a new Zephyr board definition for the FINCH CubeSat On Board Computer (OBC), based on the STM32G431 MCU.

It includes:
- Devicetree with minimal configuration for blinky
  - HSE is enabled, and PLL and RCC are configured
  - 64kB of flash is allocated for image-0
  - act_led and wrn_led are defined
- J-Link support

Tested on OBC V1.2.