### PR TITLE
manifest: limit imported modules to hal_stm32 and cmsis

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -5,7 +5,10 @@ manifest:
       url: https://github.com/zephyrproject-rtos/zephyr.git
       revision: v4.1.0
       path: zephyr
-      import: true
+      import:
+        name-allowlist:
+          - hal_stm32
+          - cmsis
       west-commands: scripts/west-commands.yml
     - name: libcsp
       url: https://github.com/libcsp/libcsp.git


### PR DESCRIPTION
Previously, all modules were imported from the Zephyr manifest, even though most were not needed for our flight software development.

This change limits the imports to only hal_stm32 and cmsis, which are the minimal required modules at this stage.

This reduces CI time, local environment setup time, and disk usage.