### PR TITLE
scripts: install_dependencies: remove apt upgrade

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-sudo apt update && sudo apt upgrade -y
+sudo apt update
 
 sudo apt install --no-install-recommends -y \
     git \


### PR DESCRIPTION
The apt upgrade operation is unnecessary and creates potential failure points for CI. Therefore, remove it.