### PR TITLE
ci: enable static code analysis

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -1,0 +1,33 @@
+name: cppcheck
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  cppcheck:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install cppcheck
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y cppcheck
+
+      - name: Run cppcheck
+        working-directory: ${{ github.workspace }}
+        run: |
+          chmod +x ./scripts/run_cppcheck.sh
+          ./scripts/run_cppcheck.sh

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Copyright (c) 2025 The FINCH CubeSat Project Flight Software Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+
+source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../finch-flight-software-env.sh"
+
+cppcheck --enable=all \
+  --suppress=missingIncludeSystem \
+  --error-exitcode=1 \
+  "${FINCH_FLIGHT_SOFTWARE_ROOT}"


### PR DESCRIPTION
Add a script for static code analysis (cppcheck) and integrate it into the CI workflow.