### PR TITLE
ci: add DNM script and workflow to block merging PRs with DNM label

### DIFF
--- a/.github/workflows/dnm.yml
+++ b/.github/workflows/dnm.yml
@@ -1,0 +1,38 @@
+name: DNM check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - edited
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  dnm-check:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install Python dependencies
+        run: |
+          pip install PyGithub
+
+      - name: Run DNM label check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          chmod +x ./scripts/dnm.py
+          ./scripts/dnm.py -p ${{ github.event.pull_request.number }}

--- a/scripts/dnm.py
+++ b/scripts/dnm.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+# Copyright 2025 Google LLC
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import os
+import sys
+
+import github
+
+DNM_LABELS = ["DNM", "DNM (manifest)", "TSC", "Architecture Review", "dev-review"]
+
+
+def parse_args(argv):
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        allow_abbrev=False,
+    )
+
+    parser.add_argument("-p", "--pull-request", required=True, type=int, help="The PR number")
+
+    return parser.parse_args(argv)
+
+
+def main(argv):
+    args = parse_args(argv)
+
+    token = os.environ.get('GITHUB_TOKEN', None)
+    gh = github.Github(token)
+    repo = gh.get_repo("utat-ss/finch-flight-software")
+    pr = repo.get_pull(args.pull_request)
+
+    for label in pr.get_labels():
+        if label.name in DNM_LABELS:
+            print(f"Pull request is labeled as \"{label.name}\".")
+            print("This workflow fails so that the pull request cannot be merged.")
+            sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
Adds a Python script and a GitHub Actions workflow to automatically block merging of pull requests if a DNM label is found