### PR TITLE
boards: pay: add initial support for PAY 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,8 @@ jobs:
             board: nucleo_g431rb
             path: ./apps/obc
             overlay: ${FINCH_FLIGHT_SOFTWARE_ROOT}/boards/overlays/nucleo_g431rb.overlay
-          - name: pay-native
-            board: native_sim
+          - name: pay-finch
+            board: pay
             path: ./apps/pay
           - name: pay-nucleo
             board: nucleo_h743zi

--- a/boards/pay/Kconfig.pay
+++ b/boards/pay/Kconfig.pay
@@ -1,0 +1,2 @@
+config BOARD_PAY
+	select SOC_STM32H743XX

--- a/boards/pay/board.cmake
+++ b/boards/pay/board.cmake
@@ -1,0 +1,8 @@
+# Copyright (c) 2025 The FINCH CubeSat Project Flight Software Contributors
+# SPDX-License-Identifier: Apache-2.0
+
+board_runner_args(pyocd "--target=stm32h743zitx")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+
+include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)

--- a/boards/pay/board.yml
+++ b/boards/pay/board.yml
@@ -1,0 +1,6 @@
+board:
+  name: pay
+  full_name: FINCH_PAY
+  vendor: The FINCH CubeSat Project Contributors
+  socs:
+    - name: stm32h743xx

--- a/boards/pay/pay.dts
+++ b/boards/pay/pay.dts
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2025 The FINCH CubeSat Project Flight Software Contributors
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/dts-v1/;
+
+#include <st/h7/stm32h743Xi.dtsi>
+
+/ {
+	model = "finch,pay";
+	compatible = "finch,pay";
+
+	chosen {
+		zephyr,sram = &sram0;
+		zephyr,flash = &flash0;
+		zephyr,code-partition = &slot0_partition;
+	};
+
+	leds: leds {
+		compatible = "gpio-leds";
+		act_led: led_0 {
+			gpios = <&gpiof 14 GPIO_ACTIVE_HIGH>;
+			label = "LED0";
+		};
+		wrn_led: led_1 {
+			gpios = <&gpiof 13 GPIO_ACTIVE_HIGH>;
+			label = "LED1";
+		};
+	};
+
+	aliases {
+		led0 = &act_led;
+		actled = &act_led;
+		led1 = &wrn_led;
+		wrnled = &wrn_led;
+	};
+};
+
+&clk_hse {
+	clock-frequency = <DT_FREQ_M(24)>;
+	status = "okay";
+};
+
+&pll {
+	div-m = <2>;
+	mul-n = <80>;
+	div-p = <2>;
+	div-q = <2>;
+	div-r = <2>;
+	clocks = <&clk_hse>;
+	status = "okay";
+};
+
+&rcc {
+	clocks = <&pll>;
+	clock-frequency = <DT_FREQ_M(480)>;
+	d1cpre = <1>;
+	hpre = <4>;
+	d1ppre = <1>;
+	d2ppre1 = <1>;
+	d2ppre2 = <1>;
+	d3ppre = <1>;
+};
+
+&flash0 {
+	partitions {
+		compatible = "fixed-partitions";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		slot0_partition: partition@0 {
+			label = "image-0";
+			reg = <0x00000000 DT_SIZE_K(128)>;
+		};
+	};
+};


### PR DESCRIPTION
Initial devicetree includes bare minimum nodes: debug leds, HSE, PLL,
RCC and flash.

SYSCLK is configured to a maximum frequency (480 MHz).