### PR TITLE
scripts: run_checkpatch: apply checkpatch to Devicetree files

### DIFF
--- a/scripts/run_checkpatch.sh
+++ b/scripts/run_checkpatch.sh
@@ -7,7 +7,8 @@ set -e
 
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../finch-flight-software-env.sh"
 
-files=$(find "${FINCH_FLIGHT_SOFTWARE_ROOT}" -type f \( -name "*.[ch]" \) ! -path "*/build/*")
+files=$(find "${FINCH_FLIGHT_SOFTWARE_ROOT}" -type f \
+    \( -name "*.[ch]" -o -name "*.dts" -o -name "*.dtsi" -o -name "*.overlay" \) ! -path "*/build/*")
 
 echo "Found the following files to be checked:"
 for i in $files; do


### PR DESCRIPTION
This patch extends checkpatch.pl coverage to include Devicetree files such as .dts, .dtsi, and .overlay.