### PR TITLE
scripts: run_cppcheck: exclude build directory in cppcheck

### DIFF
--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -8,6 +8,6 @@ set -e
 source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../finch-flight-software-env.sh"
 
 cppcheck --enable=all \
-  --suppress=missingIncludeSystem \
-  --error-exitcode=1 \
-  "${FINCH_FLIGHT_SOFTWARE_ROOT}"
+    --suppress=missingIncludeSystem \
+    --error-exitcode=1 \
+    "${FINCH_FLIGHT_SOFTWARE_ROOT}"

--- a/scripts/run_cppcheck.sh
+++ b/scripts/run_cppcheck.sh
@@ -9,5 +9,6 @@ source "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/../finch-flight-software-e
 
 cppcheck --enable=all \
     --suppress=missingIncludeSystem \
+    -i"${FINCH_FLIGHT_SOFTWARE_ROOT}/build" \
     --error-exitcode=1 \
     "${FINCH_FLIGHT_SOFTWARE_ROOT}"


### PR DESCRIPTION
The build directory should not be included in cppcheck otherwise certain macros and definitions in the build files will cause cppcheck to throw an error. And we want cppcheck to check just our source code.