### PR TITLE
ci: add OBC app build check for OBC target and remove native_sim target

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,9 +21,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: obc-native
-            board: native_sim
-            path: ./apps/obc
           - name: obc-nucleo
             board: nucleo_g431rb
             path: ./apps/obc

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - name: obc-obc
+            board: obc
+            path: ./apps/obc
           - name: obc-nucleo
             board: nucleo_g431rb
             path: ./apps/obc
@@ -76,7 +79,7 @@ jobs:
 
           echo "Commit list: $commits"
 
-          EXTRA_ARGS=""
+          EXTRA_ARGS="-DBOARD_ROOT=$FINCH_FLIGHT_SOFTWARE_ROOT"
           if [ -f "${{ matrix.overlay }}" ]; then
             EXTRA_ARGS="-- -DDTC_OVERLAY_FILE=${{ matrix.overlay }}"
           fi


### PR DESCRIPTION
This PR removes the CI build check for the OBC app targeting the native_sim board and adds OBC target, since OBC is now ready and development using peripherals that are not supported by native_sim is anticipated.