### PR TITLE
Mani/rtc internal

### DIFF
--- a/apps/obc/prj.conf
+++ b/apps/obc/prj.conf
@@ -1,5 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
+# Enable RTC support (must match your board's supported driver)
+CONFIG_COUNTER=y
+CONFIG_COUNTER_RTC_STM32=y  # For STM32 built-in RTC (like on nucleo_g431rb)
 
 CONFIG_LOG=y
 CONFIG_LOG_DEFAULT_LEVEL=3
 CONFIG_COMPILER_WARNINGS_AS_ERRORS=y
+
+# Enable printing to console
+CONFIG_SERIAL=y
+CONFIG_CONSOLE=y
+CONFIG_UART_CONSOLE=y
+CONFIG_PRINTK=y
+

--- a/apps/obc/src/main.c
+++ b/apps/obc/src/main.c
@@ -3,17 +3,86 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-
 #include <zephyr/kernel.h>
-#include <zephyr/logging/log.h>
+#include <zephyr/device.h>
+#include <zephyr/drivers/rtc.h>
+#include <zephyr/sys/util.h>
 
-LOG_MODULE_REGISTER(obc);
+
+const struct device *const rtc = DEVICE_DT_GET(DT_NODELABEL(rtc));
+
+static int set_date_time(const struct device *rtc)
+{
+    int ret = 0;
+
+    // Initialize a 'rtc_time' struct with the desired date and time
+    // Note: tm_year is years since 1900, tm_mon is 0-based (0 = January)
+    struct rtc_time tm = {
+        .tm_year = 2025 - 1900,  // Year 2025
+        .tm_mon = 6 - 1,        // November (10 in 0-based index)
+        .tm_mday = 7,           // Day of the month
+        .tm_hour = 15,            // Hour (24-hour format)
+        .tm_min = 50,            // Minutes
+        .tm_sec = 0,             // Seconds
+    };
+
+    // Set the RTC with the specified time
+    ret = rtc_set_time(rtc, &tm);
+    if (ret < 0) {
+        // If setting the time failed, print an error message with the error code
+        printk("Cannot write date time: %d\n", ret);
+        return ret;
+    }
+
+    // Return 0 if successful
+    return ret;
+}
+
+
+
+// Function to get and print the RTC date and time
+static int get_date_time(const struct device *rtc)
+{
+    int ret = 0;
+    struct rtc_time tm;  // Structure to hold the retrieved time
+
+    // Get the current time from the RTC
+    ret = rtc_get_time(rtc, &tm);
+    if (ret < 0) {
+        // If reading the time failed, print an error message with the error code
+        printk("Cannot read date time: %d\n", ret);
+        return ret;
+    }
+
+    // Print the time in human-readable format (convert year and month back)
+    printk("RTC date and time: %04d-%02d-%02d %02d:%02d:%02d\n",
+           tm.tm_year + 1900,   // Convert back to full year
+           tm.tm_mon + 1,       // Convert back to 1-based month
+           tm.tm_mday,
+           tm.tm_hour,
+           tm.tm_min,
+           tm.tm_sec);
+
+    return ret;
+}
+
 
 int main(void)
 {
-	while (1) {
-		LOG_INF("obc");
-		k_msleep(1000);
-	}
+    // Check if the RTC device is ready for use
+    if (!device_is_ready(rtc)) {
+        printk("Device is not ready\n");
+        return 0;  // Exit if RTC is not ready
+    }
+
+    // Set the date and time on the RTC
+    set_date_time(rtc);
+
+    // Infinite loop: continuously read and display the RTC date/time every 800ms
+   while (get_date_time(rtc) ==0){
+    k_sleep(K_MSEC(1000));
+   }
 	return 0;
+
 }
+


### PR DESCRIPTION
### Summary

Adds the internal RTC module and a test application to verify its functionality.

### Changes
- Added `rtc_internal.h` and `rtc_internal.c` with `set_date_time()` and `get_date_time()` implementations.
- Updated `boards/obc/Kconfig.obc` and `obc.dts` to enable RTC support on the STM32 G431RB.
- Created a test app under `tests/` with `main.c`, `prj.conf`, and `CMakeLists.txt`.
- Verified build with the following command:

```bash
west build -b nucleo_g431rb tests --pristine