### PR TITLE
.github: workflows: add build library workflow

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -1,0 +1,53 @@
+name: Zephyr Library Build Check
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build-libs:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        run: |
+          chmod +x ./scripts/install_dependencies.sh
+          ./scripts/install_dependencies.sh
+
+      - name: Setup Python venv
+        run: |
+          chmod +x ./scripts/setup_python_venv.sh
+          ./scripts/setup_python_venv.sh
+
+      - name: Setup west workspace
+        run: |
+          chmod +x ./scripts/setup_west_workspace.sh
+          ./scripts/setup_west_workspace.sh
+
+      - name: Build all libraries
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          source ../.venv/bin/activate
+          source ../zephyr/zephyr-env.sh
+          source finch-flight-software-env.sh
+
+          ../zephyr/scripts/twister -T tests --build-only -vvv -x "-- -DBOARD_ROOT=$FINCH_FLIGHT_SOFTWARE_ROOT"


### PR DESCRIPTION
Add GitHub Actions workflow to build all libraries.

Ideally all libraries would have tests, but this could act as a sort of smoke test that runs really fast.