### PR TITLE
boards: obc: board.cmake: add stm32cubeprogrammer as runner

### DIFF
--- a/boards/obc/board.cmake
+++ b/boards/obc/board.cmake
@@ -2,5 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 board_runner_args(pyocd "--target=stm32g431rbtx")
+board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)


### PR DESCRIPTION
Add STM32 Cube Programmer as a runner for OBC flashing.