### PR TITLE
boards: obc: board.cmake: add openocd support

### DIFF
--- a/boards/obc/board.cmake
+++ b/boards/obc/board.cmake
@@ -3,6 +3,8 @@
 
 board_runner_args(pyocd "--target=stm32g431rbtx")
 board_runner_args(stm32cubeprogrammer "--port=swd" "--reset-mode=hw")
+board_runner_args(openocd "--config=interface/stlink.cfg" "--config=target/stm32g4x.cfg")
 
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/openocd-stm32.board.cmake)


### PR DESCRIPTION
Add openocd support for easier GDB usage in Docker.

Flashed blinky and it worked