### PR TITLE
boards: obc: obc.dts: add support for uart

### DIFF
--- a/boards/obc/obc.dts
+++ b/boards/obc/obc.dts
@@ -7,6 +7,7 @@
 /dts-v1/;
 
 #include <st/g4/stm32g431Xb.dtsi>
+#include <dt-bindings/pinctrl/stm32-pinctrl.h>
 
 / {
 	model = "finch,obc";
@@ -71,5 +72,21 @@
 			label = "image-0";
 			reg = <0x00000000 DT_SIZE_K(64)>;
 		};
+	};
+};
+
+&usart1 {
+	pinctrl-0 = <&usart1_tx_pb7 &usart1_rx_pb6>;
+	pinctrl-names = "default";
+	status = "okay";
+};
+
+&pinctrl {
+	usart1_rx_pb6: usart1_rx_pb6 {
+		pinmux = <STM32_PINMUX('B', 6, AF7)>;
+	};
+
+	usart1_tx_pb7: usart1_tx_pb7 {
+		pinmux = <STM32_PINMUX('B', 7, AF7)>;
 	};
 };


### PR DESCRIPTION
Add support for uart for obc in the devicetree.

<img width="268" height="602" alt="Screenshot 2025-08-02 152556" src="https://github.com/user-attachments/assets/0dde0281-ae4f-437d-95e8-77d9fb82b71f" />
