### PR TITLE
scripts: setup_west_workspace: only install arm-zephyr-eabi

### DIFF
--- a/scripts/setup_west_workspace.sh
+++ b/scripts/setup_west_workspace.sh
@@ -11,4 +11,4 @@ cd "${FINCH_FLIGHT_SOFTWARE_ROOT}"
 west init --local --mf west.yml && west update
 west zephyr-export
 pip install -r "$(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}")/zephyr/scripts/requirements.txt"
-west sdk install --install-base $(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}")
+west sdk install --install-base $(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}") --toolchains arm-zephyr-eabi


### PR DESCRIPTION
All MCUs on the FINCH CubeSat are 32-bit ARM processors. Therefore, only install the arm-zephyr-eabi toolchain.