### PR TITLE
scripts: setup_west_workspace: remove a potentially misleading print

### DIFF
--- a/scripts/setup_west_workspace.sh
+++ b/scripts/setup_west_workspace.sh
@@ -12,4 +12,3 @@ west init --local --mf west.yml && west update
 west zephyr-export
 pip install -r "$(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}")/zephyr/scripts/requirements.txt"
 west sdk install --install-base $(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}")
-echo "FINCH Flight Software Development Environment setup completed."


### PR DESCRIPTION
The echo line in this script can be misleading unless the script is executed specifically as part of setting up a new FINCH flight software development environment along with other scripts, which is not necessarily the case. Also, this print didn’t add much value in the first place.