### PR TITLE
scripts: setup_west_workspace: prefer west packages over pip install

### DIFF
--- a/scripts/setup_west_workspace.sh
+++ b/scripts/setup_west_workspace.sh
@@ -10,5 +10,5 @@ source "$(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}")/.venv/bin/activate"
 cd "${FINCH_FLIGHT_SOFTWARE_ROOT}"
 west init --local --mf west.yml && west update
 west zephyr-export
-pip install -r "$(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}")/zephyr/scripts/requirements.txt"
+west packages pip --install
 west sdk install --install-base $(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}") --toolchains arm-zephyr-eabi


### PR DESCRIPTION
~~The pip install step should be performed in setup_python_venv.sh, not in setup_west_workspace.sh. Additionally, use 'west packages' to install Python dependencies, rather than directly using 'pip install'.~~

Since Zephyr v4.1.0, the official "Getting Started Guide" uses
'west packages' instead of 'pip install'. Therefore, prefer
'west packages' in scripts/setup_west_workspace.sh.

See:
https://docs.zephyrproject.org/4.0.0/develop/getting_started/index.html
https://docs.zephyrproject.org/4.1.0/develop/getting_started/index.html

