### PR TITLE
.gitattributes: set line endings for all files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,4 @@
 scripts/checkpatch.pl linguist-vendored
+*     text=auto
+*.sh  text eol=lf
+*.ps1 text eol=crlf


### PR DESCRIPTION
All files have their line endings normalized using git.
Two exceptions are .sh and .ps1 scripts: .sh scripts need LF line endings to run them properly, and .ps1 scripts use CRLF by convention.

From git documentation:
When a matching file is added to the index, the file’s line endings are normalized to LF in the index. Conversely, when the file is copied from the index to the working directory, its line endings may be converted from LF to CRLF depending on the eol attribute, the Git config, and the platform.