### PR TITLE
CI: remove sudo in install_dependencies.sh

### DIFF
--- a/.github/workflows/build-only.yml
+++ b/.github/workflows/build-only.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install dependencies
         run: |
           chmod +x ./scripts/install_dependencies.sh
-          ./scripts/install_dependencies.sh
+          sudo ./scripts/install_dependencies.sh
 
       - name: Setup Python venv
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           chmod +x ./scripts/install_dependencies.sh
-          ./scripts/install_dependencies.sh
+          sudo ./scripts/install_dependencies.sh
 
       - name: Setup Python venv
         run: |

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cd finch-flight-software
 ### Install Dependencies
 
 ```sh
-./scripts/install_dependencies.sh
+sudo ./scripts/install_dependencies.sh
 ```
 
 ### Set Up Python Virtual Environment

--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -5,9 +5,9 @@
 
 set -e
 
-sudo apt update
+apt update
 
-sudo apt install --no-install-recommends -y \
+apt install --no-install-recommends -y \
     git \
     cmake \
     ninja-build \


### PR DESCRIPTION
Before this change, sudo had to be installed in Docker first before calling the script, making it less convenient. 

After this change, the dependencies can be installed with `sudo install_dependencies.sh` in Github Actions.