### PR TITLE
scripts: install_dependencies: use 'apt-get' instead of 'apt'

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -5,9 +5,9 @@
 
 set -e
 
-apt update
+apt-get update
 
-apt install --no-install-recommends -y \
+apt-get install --no-install-recommends -y \
     git \
     cmake \
     ninja-build \


### PR DESCRIPTION
Currently, the following warning is generated:

WARNING: apt does not have a stable CLI interface.
Use with caution in scripts.

'apt' is intended for end users [1], while 'apt-get' is considered the back-end interface [2].

References:
[1] https://manpages.debian.org/trixie/apt/apt.8.en.html
[2] https://manpages.debian.org/trixie/apt/apt-get.8.en.html