### PR TITLE
CI: change the build target of eps-native

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
             path: ./apps/pay
             overlay: ${FINCH_FLIGHT_SOFTWARE_ROOT}/boards/overlays/nucleo_h743zi.overlay
           - name: eps-native
-            board: native_sim
+            board: native_sim/native/64
             path: ./apps/eps
 
     steps:


### PR DESCRIPTION
This commit changes the target to native_sim/native/64, which is supported on both x86 and ARM.