### PR TITLE
checkpatch: introduce .checkpatch.conf

### DIFF
--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -1,0 +1,31 @@
+--emacs
+--summary-file
+--show-types
+--max-line-length=100
+--min-conf-desc-length=1
+--typedefsfile=scripts/checkpatch/typedefsfile
+
+--ignore PRINTK_WITHOUT_KERN_LEVEL
+--ignore SPLIT_STRING
+--ignore VOLATILE
+--ignore CONFIG_EXPERIMENTAL
+--ignore PREFER_KERNEL_TYPES
+--ignore PREFER_SECTION
+--ignore AVOID_EXTERNS
+--ignore NETWORKING_BLOCK_COMMENT_STYLE
+--ignore DATE_TIME
+--ignore MINMAX
+--ignore CONST_STRUCT
+--ignore FILE_PATH_CHANGES
+--ignore SPDX_LICENSE_TAG
+--ignore C99_COMMENT_TOLERANCE
+--ignore REPEATED_WORD
+--ignore UNDOCUMENTED_DT_STRING
+--ignore DT_SPLIT_BINDING_PATCH
+--ignore DT_SCHEMA_BINDING_PATCH
+--ignore TRAILING_SEMICOLON
+--ignore COMPLEX_MACRO
+--ignore MULTISTATEMENT_MACRO_USE_DO_WHILE
+--ignore ENOSYS
+--ignore IS_ENABLED_CONFIG
+--ignore EXPORT_SYMBOL

--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -4,6 +4,7 @@
 --max-line-length=100
 --min-conf-desc-length=1
 --typedefsfile=scripts/checkpatch/typedefsfile
+--strict
 
 --ignore PRINTK_WITHOUT_KERN_LEVEL
 --ignore SPLIT_STRING

--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -30,3 +30,4 @@
 --ignore IS_ENABLED_CONFIG
 --ignore EXPORT_SYMBOL
 --ignore UNNECESSARY_ELSE
+--ignore NEW_TYPEDEFS

--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -32,3 +32,4 @@
 --ignore EXPORT_SYMBOL
 --ignore UNNECESSARY_ELSE
 --ignore NEW_TYPEDEFS
+--ignore BRACES

--- a/.checkpatch.conf
+++ b/.checkpatch.conf
@@ -29,3 +29,4 @@
 --ignore ENOSYS
 --ignore IS_ENABLED_CONFIG
 --ignore EXPORT_SYMBOL
+--ignore UNNECESSARY_ELSE

--- a/lib/ccsds123b/src/encoder.c
+++ b/lib/ccsds123b/src/encoder.c
@@ -15,11 +15,11 @@
 
 static void compute_k(int accumulator, int counter, int *k)
 {
-	if (2 * counter > accumulator + (int32_t)(49/128.0 * counter)) {
+	if (2 * counter > accumulator + (int32_t)(49 / 128.0 * counter)) {
 		*k = 0;
 	} else {
 		for (*k = 1; *k <= D - 2; ++(*k)) {
-			if (counter * (1 << *k) > accumulator + (int32_t)(49/128.0 * counter)) {
+			if (counter * (1 << *k) > accumulator + (int32_t)(49 / 128.0 * counter)) {
 				*k -= 1;
 				break;
 			}

--- a/lib/ccsds123b/src/encoder.c
+++ b/lib/ccsds123b/src/encoder.c
@@ -52,7 +52,9 @@ void encode_prediction(const vec3 *N, Predictions prediction, EncoderOut out)
 					}
 				}
 
-				// [5.4.3.2.2] Sample adaptive entropy encoder
+				/*
+				 * [5.4.3.2.2] Sample adaptive entropy encoder
+				 */
 				int32_t j = get_predictions(prediction, z, y, x);
 				int32_t k;
 

--- a/lib/ccsds123b/src/predictor.c
+++ b/lib/ccsds123b/src/predictor.c
@@ -109,7 +109,6 @@ void predict_image(const vec3 *N, Predictions p)
 						double_res_pred_sample,
 						predicted_sample_value);
 
-
 				/*
 				 * Prediction
 				 */

--- a/lib/ccsds123b/src/predictor.c
+++ b/lib/ccsds123b/src/predictor.c
@@ -66,13 +66,13 @@ void predict_image(const vec3 *N, Predictions p)
 					int ph = -6 + (int32_t)((t - N->x) / 16) + 10 - Omega;
 
 					weights[t + 1] = update_weight(
-						weights[t + 1],                   // omega_t: current weight
-						ez,                               // e_z_t: prediction error
-						ph,                               // p_t: scaling exponent
-						0,                                // xi_z_i: default to 0
-						get_local_diffs(local_diffs, z, y, x).central, // d_z_i_t1: central local difference
-						-(1 << (Omega + 2)),              // omega_min: -2^(Omega+2)
-						(1 << (Omega + 2)) - 1            // omega_max: 2^(Omega+2) - 1
+						weights[t + 1], /* omega_t: current weight */
+						ez, /* e_z_t: prediction error */
+						ph, /* p_t: scaling exponent */
+						0, /* xi_z_i: default to 0 */
+						get_local_diffs(local_diffs, z, y, x).central, /* d_z_i_t1: central local difference */
+						-(1 << (Omega + 2)), /* omega_min: -2^(Omega+2) */
+						(1 << (Omega + 2)) - 1 /* omega_max: 2^(Omega+2) - 1 */
 					);
 				}
 
@@ -140,8 +140,10 @@ int32_t compute_local_sum(int z, int y, int x)
 			return img_get_pxl(z, y, x - 1) + img_get_pxl(z, y - 1, x - 1) +
 				   (2 * img_get_pxl(z, y - 1, x));
 		} else {
-			// The value of local sum at t=0 is undefined since it is not
-			// needed, so we return 0.
+			/*
+			 * The value of local sum at t=0 is undefined since it is not
+			 * needed, so we return 0.
+			 */
 			return 0;
 		}
 
@@ -170,7 +172,9 @@ int32_t compute_local_sum(int z, int y, int x)
 
 LocalDiff compute_local_diffs(int z, int y, int x, int32_t local_sum)
 {
-	// t=0 is not defined.
+	/*
+	 * t=0 is not defined.
+	 */
 	if (x == 0 && y == 0) {
 		return (LocalDiff){ 0, 0, 0, 0 };
 	}
@@ -256,31 +260,43 @@ void initialize_weights(int32_t *weights, int32_t weights_size, int z, int32_t o
 int32_t update_weight(int32_t omega_t, int32_t e_z_t, int32_t p_t, int32_t xi_z_i,
 	int32_t d_z_i_t1, int32_t omega_min, int32_t omega_max)
 {
-	// Step 1: Compute sgn[e_z(t)]
+	/*
+	 * Step 1: Compute sgn[e_z(t)]
+	 */
 	int32_t sign = sgn_pos(e_z_t);
 
-	// Step 2: Compute the exponent -p(t) + xi_z^(i)
+	/*
+	 * Step 2: Compute the exponent -p(t) + xi_z^(i)
+	 */
 	int32_t exponent = -p_t + xi_z_i;
 
-	// Step 3: Compute 2^(-p(t) + xi_z^(i)) * d_z-i(t+1)
-	// Since 2^exponent can be a left or right shift:
+	/*
+	 * Step 3: Compute 2^(-p(t) + xi_z^(i)) * d_z-i(t+1)
+	 * Since 2^exponent can be a left or right shift:
+	 */
 	int32_t scaling_factor;
 
 	if (exponent >= 0) {
-		scaling_factor = d_z_i_t1 << exponent; // 2^exponent * d_z-i(t+1)
+		scaling_factor = d_z_i_t1 << exponent; /* 2^exponent * d_z-i(t+1) */
 	} else {
-		scaling_factor = d_z_i_t1 >> (-exponent); // 2^(-|exponent|) * d_z-i(t+1)
+		scaling_factor = d_z_i_t1 >> (-exponent); /* 2^(-|exponent|) * d_z-i(t+1) */
 	}
 
-	// Step 4: Compute the update term: (1/2) * sgn[e_z(t)] * 2^(-p(t) + xi_z^(i)) * d_z-i(t+1)
-	// 1/2 is a right shift by 1
+	/*
+	 * Step 4: Compute the update term: (1/2) * sgn[e_z(t)] * 2^(-p(t) + xi_z^(i)) * d_z-i(t+1)
+	 * 1/2 is a right shift by 1
+	 */
 	int32_t update_term = (sign * scaling_factor) >> 1;
 
-	// Step 5: Update omega: omega(t) + floor(update_term)
-	// Since we're using integers, the floor is implicit
+	/*
+	 * Step 5: Update omega: omega(t) + floor(update_term)
+	 * Since we're using integers, the floor is implicit
+	 */
 	int32_t new_omega = omega_t + update_term;
 
-	// Step 6: Clip the result to [omega_min, omega_max]
+	/*
+	 * Step 6: Clip the result to [omega_min, omega_max]
+	 */
 	new_omega = clip(new_omega, omega_min, omega_max);
 
 	return new_omega;
@@ -293,8 +309,10 @@ int64_t mod(int64_t M, int64_t n)
 
 int64_t compute_high_res_pred_sample(int32_t pred_cent_local_diff, int32_t local_sum, int32_t Omega, int32_t R, int32_t Smid, int32_t Smax, int32_t Smin)
 {
-	// The calculation shown at 4.7.2 can be represented in this format,
-	//   clip(modR(c1) + c2 + c3, {clip_min, clip_max})
+	/*
+	 * The calculation shown at 4.7.2 can be represented in this format,
+	 *   clip(modR(c1) + c2 + c3, {clip_min, clip_max})
+	 */
 
 	uint64_t const two_R		 = 1ULL << R;
 	uint64_t const two_R_minus_1 = 1ULL << (R - 1);

--- a/scripts/checkpatch.pl
+++ b/scripts/checkpatch.pl
@@ -113,7 +113,8 @@ Options:
   --max-line-length=n        set the maximum line length, (default $max_line_length)
                              if exceeded, warn on patches
                              requires --strict for use with --file
-  --min-conf-desc-length=n   set the min description length, if shorter, warn
+  --min-conf-desc-length=n   set the minimum description length for config symbols
+                             in lines, if shorter, warn (default $min_conf_desc_length)
   --tab-size=n               set the number of spaces for tab (default $tabsize)
   --root=PATH                PATH to the kernel tree root
   --no-summary               suppress the per-file summary
@@ -149,6 +150,24 @@ EOM
 
 	exit($exitcode);
 }
+
+my $DO_WHILE_0_ADVICE = q{
+   do {} while (0) advice is over-stated in a few situations:
+
+   The more obvious case is macros, like MODULE_PARM_DESC, invoked at
+   file-scope, where C disallows code (it must be in functions).  See
+   $exceptions if you have one to add by name.
+
+   More troublesome is declarative macros used at top of new scope,
+   like DECLARE_PER_CPU.  These might just compile with a do-while-0
+   wrapper, but would be incorrect.  Most of these are handled by
+   detecting struct,union,etc declaration primitives in $exceptions.
+
+   Theres also macros called inside an if (block), which "return" an
+   expression.  These cannot do-while, and need a ({}) wrapper.
+
+   Enjoy this qualification while we work to improve our heuristics.
+};
 
 sub uniq {
 	my %seen;
@@ -665,6 +684,9 @@ our $tracing_logging_tags = qr{(?xi:
 	return |
 	[\.\!:\s]*
 )};
+
+# Device ID types like found in include/linux/mod_devicetable.h.
+our $dev_id_types = qr{\b[a-z]\w*_device_id\b};
 
 sub edit_distance_min {
 	my (@arr) = @_;
@@ -2614,6 +2636,11 @@ sub exclude_global_initialisers {
 		$realfile =~ m@/bpf/.*\.bpf\.c$@;
 }
 
+sub is_userspace {
+    my ($realfile) = @_;
+    return ($realfile =~ m@^tools/@ || $realfile =~ m@^scripts/@);
+}
+
 sub process {
 	my $filename = shift;
 
@@ -3272,7 +3299,7 @@ sub process {
 					# file delta changes
 		      $line =~ /^\s*(?:[\w\.\-\+]*\/)++[\w\.\-\+]+:/ ||
 					# filename then :
-		      $line =~ /^\s*(?:Fixes:|$link_tags_search|$signature_tags)/i ||
+		      $line =~ /^\s*(?:Fixes:|https?:|$link_tags_search|$signature_tags)/i ||
 					# A Fixes:, link or signature tag line
 		      $commit_log_possible_stack_dump)) {
 			WARN("COMMIT_LOG_LONG_LINE",
@@ -3481,9 +3508,10 @@ sub process {
 # Check for various typo / spelling mistakes
 		if (defined($misspellings) &&
 		    ($in_commit_log || $line =~ /^(?:\+|Subject:)/i)) {
-			while ($rawline =~ /(?:^|[^\w\-'`])($misspellings)(?:[^\w\-'`]|$)/gi) {
+			my $rawline_utf8 = decode("utf8", $rawline);
+			while ($rawline_utf8 =~ /(?:^|[^\w\-'`])($misspellings)(?:[^\w\-'`]|$)/gi) {
 				my $typo = $1;
-				my $blank = copy_spacing($rawline);
+				my $blank = copy_spacing($rawline_utf8);
 				my $ptr = substr($blank, 0, $-[1]) . "^" x length($typo);
 				my $hereptr = "$hereline$ptr\n";
 				my $typo_fix = $spelling_fix{lc($typo)};
@@ -3645,7 +3673,7 @@ sub process {
 			    $help_length < $min_conf_desc_length) {
 				my $stat_real = get_stat_real($linenr, $ln - 1);
 				WARN("CONFIG_DESCRIPTION",
-				     "please write a help paragraph that fully describes the config symbol\n" . "$here\n$stat_real\n");
+				     "please write a help paragraph that fully describes the config symbol with at least $min_conf_desc_length lines\n" . "$here\n$stat_real\n");
 			}
 		}
 
@@ -3689,20 +3717,6 @@ sub process {
 			}
 		}
 
-		if (($realfile =~ /Makefile.*/ || $realfile =~ /Kbuild.*/) &&
-		    ($line =~ /\+(EXTRA_[A-Z]+FLAGS).*/)) {
-			my $flag = $1;
-			my $replacement = {
-				'EXTRA_AFLAGS' =>   'asflags-y',
-				'EXTRA_CFLAGS' =>   'ccflags-y',
-				'EXTRA_CPPFLAGS' => 'cppflags-y',
-				'EXTRA_LDFLAGS' =>  'ldflags-y',
-			};
-
-			WARN("DEPRECATED_VARIABLE",
-			     "Use of $flag is deprecated, please use \`$replacement->{$flag} instead.\n" . $herecurr) if ($replacement->{$flag});
-		}
-
 # check for DT compatible documentation
 		if (defined $root &&
 			(($realfile =~ /\.dtsi?$/ && $line =~ /^\+\s*compatible\s*=\s*\"/) ||
@@ -3731,6 +3745,18 @@ sub process {
 					WARN("UNDOCUMENTED_DT_STRING",
 					     "DT compatible string vendor \"$vendor\" appears un-documented -- check $vp_file\n" . $herecurr);
 				}
+			}
+		}
+
+# Check for RGMII phy-mode with delay on PCB
+		if ($realfile =~ /\.(dts|dtsi|dtso)$/ &&
+		    $line =~ /^\+\s*(phy-mode|phy-connection-type)\s*=\s*"/ &&
+		    !ctx_has_comment($first_line, $linenr)) {
+			my $prop = $1;
+			my $mode = get_quoted_string($line, $rawline);
+			if ($mode =~ /^"rgmii(?:|-rxid|-txid)"$/) {
+				WARN("UNCOMMENTED_RGMII_MODE",
+				     "$prop $mode without comment -- delays on the PCB should be described, otherwise use \"rgmii-id\"\n" . $herecurr);
 			}
 		}
 
@@ -4817,7 +4843,7 @@ sub process {
 		}
 
 # do not use BUG() or variants
-		if ($line =~ /\b(?!AA_|BUILD_|DCCP_|IDA_|KVM_|RWLOCK_|snd_|SPIN_)(?:[a-zA-Z_]*_)?BUG(?:_ON)?(?:_[A-Z_]+)?\s*\(/) {
+		if ($line =~ /\b(?!AA_|BUILD_|IDA_|KVM_|RWLOCK_|snd_|SPIN_)(?:[a-zA-Z_]*_)?BUG(?:_ON)?(?:_[A-Z_]+)?\s*\(/) {
 			my $msg_level = \&WARN;
 			$msg_level = \&CHK if ($file);
 			&{$msg_level}("AVOID_BUG",
@@ -5896,9 +5922,9 @@ sub process {
 			}
 		}
 
-# multi-statement macros should be enclosed in a do while loop, grab the
-# first statement and ensure its the whole macro if its not enclosed
-# in a known good container
+# Usually multi-statement macros should be enclosed in a do {} while
+# (0) loop.  Grab the first statement and ensure its the whole macro
+# if its not enclosed in a known good container
 		if ($realfile !~ m@/vmlinux.lds.h$@ &&
 		    $line =~ /^.\s*\#\s*define\s*$Ident(\()?/) {
 			my $ln = $linenr;
@@ -5951,10 +5977,13 @@ sub process {
 
 			my $exceptions = qr{
 				$Declare|
+				# named exceptions
 				module_param_named|
 				MODULE_PARM_DESC|
 				DECLARE_PER_CPU|
 				DEFINE_PER_CPU|
+				static_assert|
+				# declaration primitives
 				__typeof__\(|
 				union|
 				struct|
@@ -5989,11 +6018,11 @@ sub process {
 					ERROR("MULTISTATEMENT_MACRO_USE_DO_WHILE",
 					      "Macros starting with if should be enclosed by a do - while loop to avoid possible if/else logic defects\n" . "$herectx");
 				} elsif ($dstat =~ /;/) {
-					ERROR("MULTISTATEMENT_MACRO_USE_DO_WHILE",
-					      "Macros with multiple statements should be enclosed in a do - while loop\n" . "$herectx");
+					WARN("MULTISTATEMENT_MACRO_USE_DO_WHILE",
+					      "Non-declarative macros with multiple statements should be enclosed in a do - while loop\n" . "$herectx\nBUT SEE:\n$DO_WHILE_0_ADVICE");
 				} else {
 					ERROR("COMPLEX_MACRO",
-					      "Macros with complex values should be enclosed in parentheses\n" . "$herectx");
+					      "Macros with complex values should be enclosed in parentheses\n" . "$herectx\nBUT SEE:\n$DO_WHILE_0_ADVICE");
 				}
 
 			}
@@ -6037,7 +6066,7 @@ sub process {
 				}
 
 # check if this is an unused argument
-				if ($define_stmt !~ /\b$arg\b/) {
+				if ($define_stmt !~ /\b$arg\b/ && $define_stmt) {
 					WARN("MACRO_ARG_UNUSED",
 					     "Argument '$arg' is not used in function-like macro\n" . "$herectx");
 				}
@@ -6904,7 +6933,7 @@ sub process {
 					    ($extension eq "f" &&
 					     defined $qualifier && $qualifier !~ /^w/) ||
 					    ($extension eq "4" &&
-					     defined $qualifier && $qualifier !~ /^cc/)) {
+					     defined $qualifier && $qualifier !~ /^c(?:[hlbc]|hR)$/)) {
 						$bad_specifier = $specifier;
 						last;
 					}
@@ -6994,21 +7023,20 @@ sub process {
 #				}
 #			}
 #		}
-
 # strcpy uses that should likely be strscpy
-		if ($line =~ /\bstrcpy\s*\(/) {
+		if ($line =~ /\bstrcpy\s*\(/ && !is_userspace($realfile)) {
 			WARN("STRCPY",
 			     "Prefer strscpy over strcpy - see: https://github.com/KSPP/linux/issues/88\n" . $herecurr);
 		}
 
 # strlcpy uses that should likely be strscpy
-		if ($line =~ /\bstrlcpy\s*\(/) {
+		if ($line =~ /\bstrlcpy\s*\(/ && !is_userspace($realfile)) {
 			WARN("STRLCPY",
 			     "Prefer strscpy over strlcpy - see: https://github.com/KSPP/linux/issues/89\n" . $herecurr);
 		}
 
 # strncpy uses that should likely be strscpy or strscpy_pad
-		if ($line =~ /\bstrncpy\s*\(/) {
+		if ($line =~ /\bstrncpy\s*\(/ && !is_userspace($realfile)) {
 			WARN("STRNCPY",
 			     "Prefer strscpy, strscpy_pad, or __nonstring over strncpy - see: https://github.com/KSPP/linux/issues/90\n" . $herecurr);
 		}
@@ -7667,6 +7695,31 @@ sub process {
 		if ($line =~ /\.extra[12]\s*=\s*&(zero|one|int_max)\b/) {
 			WARN("DUPLICATED_SYSCTL_CONST",
 				"duplicated sysctl range checking value '$1', consider using the shared one in include/linux/sysctl.h\n" . $herecurr);
+		}
+
+# Check that *_device_id tables have sentinel entries.
+		if (defined $stat && $line =~ /struct\s+$dev_id_types\s+\w+\s*\[\s*\]\s*=\s*\{/) {
+			my $stripped = $stat;
+
+			# Strip diff line prefixes.
+			$stripped =~ s/(^|\n)./$1/g;
+			# Line continuations.
+			$stripped =~ s/\\\n/\n/g;
+			# Strip whitespace, empty strings, zeroes, and commas.
+			$stripped =~ s/""//g;
+			$stripped =~ s/0x0//g;
+			$stripped =~ s/[\s$;,0]//g;
+			# Strip field assignments.
+			$stripped =~ s/\.$Ident=//g;
+
+			if (!(substr($stripped, -4) eq "{}};" ||
+			      substr($stripped, -6) eq "{{}}};" ||
+			      $stripped =~ /ISAPNP_DEVICE_SINGLE_END}};$/ ||
+			      $stripped =~ /ISAPNP_CARD_END}};$/ ||
+			      $stripped =~ /NULL};$/ ||
+			      $stripped =~ /PCMCIA_DEVICE_NULL};$/)) {
+				ERROR("MISSING_SENTINEL", "missing sentinel in ID array\n" . "$here\n$stat\n");
+			}
 		}
 	}
 

--- a/scripts/run_checkpatch.sh
+++ b/scripts/run_checkpatch.sh
@@ -23,8 +23,7 @@ exit_code=0
 for i in $files; do
     echo "Running checkpatch on $i"
     chmod +x "${FINCH_FLIGHT_SOFTWARE_ROOT}/scripts/checkpatch.pl"
-    perl "${FINCH_FLIGHT_SOFTWARE_ROOT}/scripts/checkpatch.pl" --mailback --no-tree -f --emacs --summary-file --show-types \
-         --ignore BRACES,PRINTK_WITHOUT_KERN_LEVEL,SPLIT_STRING,SPDX_LICENSE_TAG,UNNECESSARY_ELSE,NEW_TYPEDEFS --max-line-length=100 "$i"
+    cd "${FINCH_FLIGHT_SOFTWARE_ROOT}" && ./scripts/checkpatch.pl --no-tree -f "$i"
     ret=$?
     if [ $ret -ne 0 ]; then
          exit_code=1

--- a/tests/ccsds123b/debug/src/reconstructor.c
+++ b/tests/ccsds123b/debug/src/reconstructor.c
@@ -22,10 +22,14 @@ void decode_encoding(
 				int decoded_j;
 				int decoded_k;
 
-				// Decode the GPO2 string to get the original prediction value 'j'
+				/*
+				 * Decode the GPO2 string to get the original prediction value 'j'
+				 */
 				decode_gpo2(encoding[z][y][x], &decoded_j, &decoded_k);
 
-				// Store the decoded 'j' value into the prediction array
+				/*
+				 * Store the decoded 'j' value into the prediction array
+				 */
 				prediction[z][y][x] = decoded_j;
 			}
 		}
@@ -40,36 +44,50 @@ void decode_gpo2(const char in[32], int *j, int *k)
 		return;
 	}
 
-		// Determine k and prefix based on the structure of the encoded string
-	// The suffix is the initial 'k' bits
-	// The '1' after the suffix marks the end of the suffix and the start of the prefix '0's
-	// The number of '0's after the '1' determines the prefix value
+		/*
+		 * Determine k and prefix based on the structure of the encoded string
+		 */
+	/*
+	 * The suffix is the initial 'k' bits
+	 * The '1' after the suffix marks the end of the suffix and the start of the prefix '0's
+	 * The number of '0's after the '1' determines the prefix value
+	 */
 
 	unsigned int suffix_val = 0;
 	int suffix_len = 0;
 	int index = 0;
 
-	// Read the suffix bits (until '1' is encountered)
+	/*
+	 * Read the suffix bits (until '1' is encountered)
+	 */
 	while (in[index] == '0' || in[index] == '1') {
-		// Check if the current character is '1', which marks the end of suffix bits
+		/*
+		 * Check if the current character is '1', which marks the end of suffix bits
+		 */
 		if (in[index] == '1') {
-			// This '1' is part of the prefix-marker, not the suffix bits.
-			// Suffix bits are inverted in order in the string.
-			// Suffix length is the number of bits before this '1'.
+			/*
+			 * This '1' is part of the prefix-marker, not the suffix bits.
+			 * Suffix bits are inverted in order in the string.
+			 * Suffix length is the number of bits before this '1'.
+			 */
 			suffix_len = index;
 			break;
 		}
 		index++;
 	}
 
-	// Reconstruct the suffix value
+	/*
+	 * Reconstruct the suffix value
+	 */
 	for (int i = 0; i < suffix_len; ++i) {
 		if (in[i] == '1') {
 			suffix_val |= (1 << (suffix_len - 1 - i));
 		}
 	}
 
-	// Move past the '1' marker
+	/*
+	 * Move past the '1' marker
+	 */
 	index++;
 
 	unsigned int prefix_val = 0;
@@ -144,7 +162,9 @@ void reconstruct_prediction(
 			for (int x = 0; x < N->x; ++x, ++t) {
 				int64_t mapped_quantizer_index = image[z][y][x];
 
-				// Step 1: Compute predicted_sample_value (needed for unmapping)
+				/*
+				 * Step 1: Compute predicted_sample_value (needed for unmapping)
+				 */
 				int32_t local_sum = compute_local_sum(z, y, x);
 
 				local_diff[z][y][x] = compute_local_diffs(z, y, x, local_sum);
@@ -154,22 +174,26 @@ void reconstruct_prediction(
 				int64_t double_res_pred_sample = double_resolution_predicted_sample(high_res_pred_sample, z, t);
 				int64_t predicted_sample_value = predicted_sample(double_res_pred_sample);
 
-				// Step 2: Reverse compute_mapped_quantizer_index to get quantizer_index
+				/*
+				 * Step 2: Reverse compute_mapped_quantizer_index to get quantizer_index
+				 */
 				int64_t theta = fmin(predicted_sample_value - Smin, Smax - predicted_sample_value);
 				int64_t quantizer_index;
 
 				if (mapped_quantizer_index > 2 * theta) {
-					quantizer_index = mapped_quantizer_index - theta; // Case: abs(quantizer_index) > theta
+					quantizer_index = mapped_quantizer_index - theta; /* Case: abs(quantizer_index) > theta */
 				} else {
 					int64_t is_even = mapped_quantizer_index % 2 == 0;
 					int64_t abs_q = is_even ? mapped_quantizer_index / 2 : (mapped_quantizer_index + 1) / 2;
-					int64_t d = double_res_pred_sample % 2; // Parity from double_res_pred_sample
+					int64_t d = double_res_pred_sample % 2; /* Parity from double_res_pred_sample */
 
 					quantizer_index = is_even ? abs_q : -abs_q;
-					quantizer_index *= (d == 0 ? 1 : -1); // Apply sign based on parity
+					quantizer_index *= (d == 0 ? 1 : -1); /* Apply sign based on parity */
 				}
 
-				// Step 3: Reverse compute_quantizer_index to get prediction_residual
+				/*
+				 * Step 3: Reverse compute_quantizer_index to get prediction_residual
+				 */
 				int64_t prediction_residual;
 
 				if (x == 0 && y == 0) {


### PR DESCRIPTION
This PR introduces .checkpatch.conf, which was obtained from the upstream Zephyr Project v4.2.0 with a modification of adding --strict.
https://raw.githubusercontent.com/zephyrproject-rtos/zephyr/refs/tags/v4.2.0/.checkpatch.conf

Although this .checkpatch.conf has no SPDX ID, there is an Apache-2.0 license at the root of the upstream Zephyr Project Git repository.
Therefore, .checkpatch.conf is distributed under Apache-2.0 and is being redistributed here under the same license.

This PR also aims to address https://github.com/utat-ss/finch-flight-software/issues/116.