### PR TITLE
scripts: download Zephyr SDK to zephyr-sdk folder

### DIFF
--- a/scripts/setup_west_workspace.sh
+++ b/scripts/setup_west_workspace.sh
@@ -11,4 +11,4 @@ cd "${FINCH_FLIGHT_SOFTWARE_ROOT}"
 west init --local --mf west.yml && west update
 west zephyr-export
 west packages pip --install
-west sdk install --install-base $(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}") --toolchains arm-zephyr-eabi
+west sdk install --install-dir $(dirname "${FINCH_FLIGHT_SOFTWARE_ROOT}")/zephyr-sdk --toolchains arm-zephyr-eabi


### PR DESCRIPTION
This commit changes the download directory from "zephyr-sdk-x.xx.x" to "zephyr-sdk", making the name constant and predictable.

This way scripts can access tools in the Zephyr SDK using a fixed path.