### PR TITLE
README.md: add Fedora 42 to the supported OS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 The FINCH-FLIGHT-SOFTWARE officially supports development on the following operating systems:
 - Ubuntu 24.04 (x86_64)
+- Fedora 42 (x86_64)
 - macOS 15 (AArch64)
 - Windows 11 (x86_64)
 


### PR DESCRIPTION
Fedora 42 was extensively used during the development process of the Docker dev environment.