### PR TITLE
scripts: gdb_server.ps1: add missing --target for pcb flashing

### DIFF
--- a/scripts/gdb_server.ps1
+++ b/scripts/gdb_server.ps1
@@ -24,7 +24,7 @@ while ($true) {
         pyocd gdbserver --connect attach --allow-remote --pack ${G4Pack} --pack ${H7Pack}
     }
     elseif ($args.Count -eq 1) {
-        pyocd gdbserver $args[0] --connect attach --allow-remote --pack ${G4Pack} --pack ${H7Pack}
+        pyocd gdbserver --target $args[0] --connect attach --allow-remote --pack ${G4Pack} --pack ${H7Pack}
     }
 
     if ($LastExitCode -ne 0) {


### PR DESCRIPTION
Add missing --target argument for PCB flashing. It was mistakenly removed.