### PR TITLE
lib: Refactor initialize_weights

### DIFF
--- a/include/finch/ccsds123b/predictor.h
+++ b/include/finch/ccsds123b/predictor.h
@@ -63,6 +63,7 @@ int32_t compute_pred_cent_local_diff(
  */
 void initialize_weights(
 	int32_t *weights,
+	int32_t weights_size,
 	int z,
 	int32_t omega
 );

--- a/lib/ccsds123b/src/predictor.c
+++ b/lib/ccsds123b/src/predictor.c
@@ -41,9 +41,10 @@ void predict_image(const vec3 *N, Predictions p)
 	LOG_DBG("-----------------------------------\nQuantizer index\n");
 
 	for (int z = 0; z < N->z; ++z) {
-		int32_t weights[Pz(z) + 3];
+		int32_t weights_size = Pz(z) + 3;
+		int32_t weights[weights_size];
 
-		initialize_weights(weights, z, Omega);
+		initialize_weights(weights, weights_size, z, Omega);
 
 		for (int y = 0, t = 0; y < N->y; ++y) {
 			for (int x = 0; x < N->x; ++x, ++t) {
@@ -234,7 +235,7 @@ int32_t compute_pred_cent_local_diff(int32_t z, int32_t y, int32_t x, LocalDiffs
 	return inner_product(weights, local_diff_vec, Cz(z));
 }
 
-void initialize_weights(int32_t *weights, int z, int32_t omega)
+void initialize_weights(int32_t *weights, int32_t weights_size, int z, int32_t omega)
 {
 	for (int i = 0; i < 3; i++) {
 		weights[i] = 0;
@@ -244,7 +245,7 @@ void initialize_weights(int32_t *weights, int z, int32_t omega)
 
 	weights[3] = (7 * two_omega) >> 3; /* 7/8 * 2^omega */
 
-	for (int i = 4; i < 3 + Pz(z); ++i) {
+	for (int i = 4; i < weights_size; ++i) {
 		weights[i] = weights[i - 1] >> 3; /* floor(1/8 * weights[i-1]) */
 	}
 }

--- a/tests/ccsds123b/debug/src/reconstructor.c
+++ b/tests/ccsds123b/debug/src/reconstructor.c
@@ -125,6 +125,7 @@ void reconstruct_prediction(
 	LocalDiff local_diff[N->z][N->y][N->z];
 
 	int weights[P + 3];
+	int weights_size = P + 3;
 
 	for (int z = 0; z < N->z; ++z) {
 		for (int y = 0; y < N->y; ++y) {
@@ -135,7 +136,7 @@ void reconstruct_prediction(
 	}
 
 	for (int z = 0; z < N->z; ++z) {
-		initialize_weights(weights, z, Omega);
+		initialize_weights(weights, weights_size, z, Omega);
 
 		int t = 0;
 


### PR DESCRIPTION
Refactor initialize_weights to take the size of the weights array instead of hardcoding it in the function