### PR TITLE
CONTRIBUTING: Improved commit message guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,3 +90,24 @@ Well-written commit messages are important for project history and tools like `g
 which help contributors and maintainers understand the origin and reasoning behind specific changes.
 Also, note that each line must not exceed 72 characters, and the Git author name and email address
 must match those used in the DCO signoff.
+
+Note that `[area]` identifies the area of the code being changed. You can use multiple areas to better describe the context.
+If you’re not sure what to use, try running git log `FILE`, where `FILE` is a file you are changing, and using previous commits that changed the same file as inspiration.
+Here are some examples of areas.
+
+- `drivers: foo:` for foo driver changes
+- `lib: ccsds123b:` for changes to the ccsds123b algorithm in lib
+- `doc:` for changes to the documentation
+
+Here is an example of a good commit message.
+
+```
+drivers: sensor: abcd1234: fix bus I/O error handling
+
+The abcd1234 sensor driver is failing to check the flags field in
+the response packet from the device which signals that an error
+occurred. This can lead to reading invalid data from the response
+buffer. Fix it by checking the flag and adding an error path.
+
+Signed-off-by: Your Name <developer@example.com>
+```


### PR DESCRIPTION
Added guidelines for writing effective commit messages, including examples and formatting rules. These clarify some issues I had when writing commit messages as a new contributor, as discussed in https://github.com/utat-ss/finch-flight-software/pull/130. Note that I also added an explanation of how `[area]` works even though that was not discussed in the PR, because I think it may provide further clarification, along with providing the suggestion of `git log [FILE]`.