### PR TITLE
lib: ccsds123b: fix hardcoding of local diffs vec

### DIFF
--- a/lib/ccsds123b/src/predictor.c
+++ b/lib/ccsds123b/src/predictor.c
@@ -31,7 +31,7 @@ static int32_t sgn_pos(int x)
 
 static inline int get_weights_size(int z)
 {
-    return 3 + Pz(z);
+	return 3 + Pz(z);
 }
 
 int32_t prev_quantizer;


### PR DESCRIPTION
The function hardcodes the size of the array to Cz(z). 
We assume that its size is the same as weights and pass the size of weights and a pointer to local diff vec as parameters instead. 

Signed-off-by: Roman Navarrete romansaballanavarrete@gmail.com