### PR TITLE
manifest: pin libcsp at f8c366e

### DIFF
--- a/west.yml
+++ b/west.yml
@@ -12,5 +12,5 @@ manifest:
       west-commands: scripts/west-commands.yml
     - name: libcsp
       url: https://github.com/libcsp/libcsp.git
-      revision: v2.0
+      revision: f8c366e5dfd9879990747d815ff5b2c2dda4dfe3
       path: modules/lib/libcsp


### PR DESCRIPTION
libcsp v2.0 does not build with Zephyr 3.1 or above since the new zephyr/ prefix was introduced.

While the clean and ideal solution is to apply patches through 'west patch', there have been many changes since the release of libcsp v2.0, and it also requires multiple patches unrelated to the new zephyr/ prefix.

Since there have been so many changes since v2.0, moving to a newer version is likely a better approach. Therefore, pin libcsp at f8c366e5dfd9879990747d815ff5b2c2dda4dfe3, which is the latest as of when this patch was created.

Just to be extra clear, f8c366e5dfd9879990747d815ff5b2c2dda4dfe3 is not a stable release.

Also, prefer using the full SHA rather than the tag since Git tags are just refs.